### PR TITLE
Extract shared rules to rules.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.log
 /node_modules/

--- a/base.js
+++ b/base.js
@@ -1,17 +1,11 @@
 module.exports = {
-  extends: ['eslint-config-airbnb-base'].map(require.resolve),
+  extends: [
+    'eslint-config-airbnb-base',
+    './rules',
+  ].map(require.resolve),
   rules: {
-    // Allow dangling underscore, e.g. for manual Jest mocks
-    // http://eslint.org/docs/rules/no-underscore-dangle
-    'no-underscore-dangle': 0,
-    // Allow calling functions before their definition
-    // http://eslint.org/docs/rules/no-use-before-define
-    'no-use-before-define': [2, 'nofunc'],
     // Use the spread operator instead of .apply()
     // http://eslint.org/docs/rules/prefer-spread
     'prefer-spread': 2,
-    // Validate JSDoc
-    // http://eslint.org/docs/rules/valid-jsdoc
-    'valid-jsdoc': [2, { requireReturn: false }],
   },
 };

--- a/legacy.js
+++ b/legacy.js
@@ -1,5 +1,8 @@
 module.exports = {
-  extends: ['eslint-config-airbnb-base/legacy'].map(require.resolve),
+  extends: [
+    'eslint-config-airbnb-base/legacy',
+    './rules',
+  ].map(require.resolve),
   rules: {
     // Allow var declarations in the middle of their scope
     // http://eslint.org/docs/rules/vars-on-top

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     "eslint-plugin-react": "^5.0.1"
   },
   "devDependencies": {
-    "eslint": "^2.8.0",
+    "eslint": "^2.9.0",
     "eslint-config-airbnb": "^8.0.0",
-    "eslint-config-airbnb-base": "^1.0.4",
-    "eslint-plugin-import": "^1.6.0"
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-import": "^1.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "EventMobi's base ESLint configuration",
   "main": "index.js",
   "scripts": {
+    "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/rules.js
+++ b/rules.js
@@ -1,0 +1,14 @@
+/*
+ * Rules shared between the base and legacy configs
+ */
+module.exports = {
+  // Allow dangling underscore, e.g. for manual Jest mocks
+  // http://eslint.org/docs/rules/no-underscore-dangle
+  'no-underscore-dangle': 0,
+  // Allow calling functions before their definition
+  // http://eslint.org/docs/rules/no-use-before-define
+  'no-use-before-define': [2, 'nofunc'],
+  // Validate JSDoc
+  // http://eslint.org/docs/rules/valid-jsdoc
+  'valid-jsdoc': [2, { requireReturn: false }],
+};


### PR DESCRIPTION
Primary change here is extracting our rules into `rules.js` so they can be shared between `base.js` and `legacy.js`.
