### PR TITLE
Allow modules with a single export to use a named export

### DIFF
--- a/base.js
+++ b/base.js
@@ -17,5 +17,8 @@ module.exports = {
     // allow a default import name to match a named export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
     'import/no-named-as-default': 0,
+    // Allow modules with a single export to use a named export
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
+    'import/prefer-default-export': 0
   },
 };


### PR DESCRIPTION
For modules like 'utils.js' containing only one utility so far, this rule is undesirably triggered
