### PR TITLE
(temp) allow non-import statements to appear before import statements

### DIFF
--- a/base.js
+++ b/base.js
@@ -14,6 +14,9 @@ module.exports = {
       optionalDependencies: true,
       peerDependencies: true,
     }],
+    // disallow non-import statements appearing before import statements
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/imports-first.md
+    'import/imports-first': 0, // disabled, pending https://github.com/benmosher/eslint-plugin-import/issues/472
     // allow a default import name to match a named export
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-as-default.md
     'import/no-named-as-default': 0,


### PR DESCRIPTION
Will re-enable after https://github.com/benmosher/eslint-plugin-import/issues/472 is resolved
